### PR TITLE
Remove borders for tables and nested tables markup elements

### DIFF
--- a/src/main/asciidoc/white_course.css
+++ b/src/main/asciidoc/white_course.css
@@ -503,3 +503,8 @@ section.title {
 ul.none {
   list-style: none;
 }
+
+
+table, tr, td, th {
+  border: none !important;
+}


### PR DESCRIPTION
Changes:
force disable css border styles for table elements

Before:
<img width="1763" alt="Screenshot 2024-05-03 at 10 49 29" src="https://github.com/inponomarev/mocks-talk/assets/586380/7eed3bf7-3fb4-4ef3-a89d-6135faf650f8">


After:
<img width="1763" alt="Screenshot 2024-05-03 at 10 49 27" src="https://github.com/inponomarev/mocks-talk/assets/586380/86cff9ba-2c60-405c-9deb-9daec6a3d37a">
